### PR TITLE
fix: handle multiple potential PR numbers in commit message

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -20,7 +20,7 @@ function get_pr_from_api_response() {
 
 function get_pr_from_git() {
   local commits=${1:-1}
-  git log --pretty=format:%s -${commits} 2>/dev/null | grep -o '#[0-9]\+' | grep -o '[0-9]\+' | head -1
+  git log --pretty=format:%s -${commits} 2>/dev/null | grep -oE '\(#([0-9]+)\)' | tail -1 | grep -oE '[0-9]+'
 }
 
 # Process variables and inputs

--- a/action.sh
+++ b/action.sh
@@ -20,7 +20,13 @@ function get_pr_from_api_response() {
 
 function get_pr_from_git() {
   local commits=${1:-1}
-  git log --pretty=format:%s -${commits} 2>/dev/null | grep -oE '\(#([0-9]+)\)' | tail -1 | grep -oE '[0-9]+'
+  git log --pretty=format:%s -${commits} 2>/dev/null | while read line; do
+    trimmed=$(echo "$line" | sed 's/[[:space:]]*$//')
+    if [[ $trimmed =~ \(#([0-9]+)\)$ ]]; then
+      echo "${BASH_REMATCH[1]}"
+      break
+    fi
+  done
 }
 
 # Process variables and inputs


### PR DESCRIPTION
## Summary

This PR enforces stricter PR extraction from commit messages by matching only the PR number at the end of the line, trimming any trailing whitespace. This ensures maximum reliability and aligns with GitHub’s squash merge standard.

- Uses end-of-line regex for PR extraction
- Trims whitespace for robustness
- Prevents accidental issue number matches earlier in the commit