### PR TITLE
feat: support private repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,8 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v6
+      with:
+        token: ${{ inputs.token }}
 
     - id: vars
       shell: bash


### PR DESCRIPTION
## Summary

The action already has a `token` input (defaulting to `${{ github.token }}`) but wasn't passing it to the `actions/checkout@v6` step. Add explicit `with: token:` to use it.

## Why

When `action-get-pr` is called from a private repository (via a reusable workflow in another repo), the implicit checkout may fail without an explicit token. The token input already exists; we just need to wire it to the checkout step.

This is part of fixing the broader issue where private-repo consumers of bcgov reusable workflows encounter checkout failures.

## Changes

- Line 31-32: Add `with: token: ${{ inputs.token }}` to the checkout step

Relates to bcgov/quickstart-openshift-helpers#247