### PR TITLE
fix(inputs): switch optional input to github_token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   debug:
     description: Enable debug logging
     default: "false"
-  token:
+  github_token:
     description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
     default: ${{ github.token }}
 
@@ -29,13 +29,13 @@ runs:
   steps:
     - uses: actions/checkout@v6
       with:
-        token: ${{ inputs.token }}
+        token: ${{ inputs.github_token }}
 
     - id: vars
       shell: bash
       env:
         INPUT_DEBUG: ${{ inputs.debug }}
-        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_TOKEN: ${{ inputs.github_token }}
         MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         GITHUB_EVENT_AFTER: ${{ github.event.after }}
         GITHUB_EVENT_NUMBER: ${{ github.event.number }}

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Private repositories may need to provide a GitHub token.
 - id: vars
   uses: bcgov/action-get-pr@vX.Y.Z
   with:
-    token: ${{ secrets.GITHUB_TOKEN }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
 
 - name: Echo PR number
   run: echo "PR: ${{ steps.vars.outputs.pr }}"


### PR DESCRIPTION
This PR renames the 'token' input parameter to 'github_token' to align with standard GitHub Actions conventions and avoid naming ambiguity.