### PR TITLE
Fix regex merge group

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ async function main() {
     if (mergeGroupHeadRef) {
       // Matches both the old format (queue/<branch>/pr-<number>)
       // and the current GitHub format (refs/heads/gh-readonly-queue/<branch>/pr-<number>-<sha>)
-      const match = mergeGroupHeadRef.match(/\/pr-(\d+)/);
+      const match = mergeGroupHeadRef.match(/\/pr-(\d+)(?:-[0-9a-f]+)?$/);
       if (match) pr = match[1];
     }
   } else if (eventName === 'push' || eventName === 'release' || eventName === 'workflow_dispatch') {

--- a/index.js
+++ b/index.js
@@ -86,8 +86,9 @@ async function main() {
     }
 
     if (mergeGroupHeadRef) {
-      // Format: queue/<branch>/pr-<number>
-      const match = mergeGroupHeadRef.match(/^queue\/[^\/]+\/pr-(\d+)/);
+      // Matches both the old format (queue/<branch>/pr-<number>)
+      // and the current GitHub format (refs/heads/gh-readonly-queue/<branch>/pr-<number>-<sha>)
+      const match = mergeGroupHeadRef.match(/\/pr-(\d+)/);
       if (match) pr = match[1];
     }
   } else if (eventName === 'push' || eventName === 'release' || eventName === 'workflow_dispatch') {


### PR DESCRIPTION
The action does not parse the PR number correctly when the `head_ref` of the merge_group is in this format `"head_ref": "refs/heads/gh-readonly-queue/main/pr-4243-<sha>"`
